### PR TITLE
fix: preserve source-container recovery under cpu shed

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27989,6 +27989,14 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
       targetId: threatenedBarrierRepairTarget.id
     });
   }
+  const energyStarvedSourceLogisticsConstructionTask = selectEnergyStarvedSourceLogisticsConstructionRecoveryTask(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (energyStarvedSourceLogisticsConstructionTask) {
+    return applyMinimumUsefulLoadPolicy(creep, energyStarvedSourceLogisticsConstructionTask);
+  }
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   const coveredLowBucketControllerProgressTask = controller && !priorityTowerEnergySink && shouldRunConstructionCpuWork(cpuBudget) ? selectCoveredSurplusControllerProgressTask(creep, controller, constructionSites) : null;
   if (coveredLowBucketControllerProgressTask) {
@@ -28080,6 +28088,33 @@ function selectNonCriticalCpuLoadedControllerProgressTask(creep, cpuBudget) {
   }
   const controller = creep.room.controller;
   return (controller == null ? void 0 : controller.my) === true && canUpgradeController(controller) ? { type: "upgrade", targetId: controller.id } : null;
+}
+function selectEnergyStarvedSourceLogisticsConstructionRecoveryTask(creep, constructionSites, constructionReservationContext) {
+  const constructionSite = selectEnergyStarvedSourceLogisticsConstructionRecoverySite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
+}
+function selectEnergyStarvedSourceLogisticsConstructionRecoverySite(creep, constructionSites, constructionReservationContext) {
+  if (!canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep)) {
+    return null;
+  }
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    (site) => isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext),
+    { priorityContext, requireReasonableRange: true }
+  );
+}
+function canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep) {
+  var _a2;
+  const carriedEnergy = getUsedEnergy2(creep);
+  const roomEnergy = getRoomEnergyAvailable11(creep.room);
+  return carriedEnergy > 0 && getActiveWorkParts2(creep) > 0 && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !hasVisibleHostilePresence3(creep.room) && !shouldGuardControllerDowngrade2(creep.room.controller) && !hasActiveSpawningSpawn(creep.room) && !hasOtherSameRoomBuildCoverageWorker(creep) && roomEnergy !== null && roomEnergy - carriedEnergy >= MINIMUM_WORKER_SPAWN_ENERGY;
 }
 function selectConstructionRecoveryCpuWorkerTask(creep) {
   var _a2;
@@ -30931,9 +30966,15 @@ function isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext
   }
   const priority = getConstructionSiteImpactPriority(site, priorityContext);
   if (isContainerConstructionSite3(site)) {
-    return priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer;
+    return priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer || isSourceAdjacentContainerConstructionSite(site, priorityContext);
   }
   return isRoadConstructionSite2(site) && priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad;
+}
+function isSourceAdjacentContainerConstructionSite(site, priorityContext) {
+  return isContainerConstructionSite3(site) && Array.isArray(priorityContext.sources) && priorityContext.sources.some((source) => {
+    const range = getRangeBetweenRoomObjectPositions(site, source);
+    return range !== null && range <= 1;
+  });
 }
 function canSpendOnStoredProtectedSourceContainerConstruction(creep, site, priorityContext) {
   return isSourceContainerConstructionSite2(site, priorityContext) && !hasVisibleHostilePresence3(creep.room) && checkEnergyBufferForStoredConstructionSpending(creep.room) && !hasSameRoomWorkerAssignedToTask(creep.room, creep, "build");

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28114,7 +28114,7 @@ function canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep) {
   var _a2;
   const carriedEnergy = getUsedEnergy2(creep);
   const roomEnergy = getRoomEnergyAvailable11(creep.room);
-  return carriedEnergy > 0 && getActiveWorkParts2(creep) > 0 && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !hasVisibleHostilePresence3(creep.room) && !shouldGuardControllerDowngrade2(creep.room.controller) && !hasActiveSpawningSpawn(creep.room) && !hasOtherSameRoomBuildCoverageWorker(creep) && roomEnergy !== null && roomEnergy >= MINIMUM_WORKER_SPAWN_ENERGY;
+  return carriedEnergy > 0 && getActiveWorkParts2(creep) > 0 && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !hasVisibleHostilePresence3(creep.room) && !shouldGuardControllerDowngrade2(creep.room.controller) && !isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep) && !hasOtherSameRoomBuildCoverageWorker(creep) && roomEnergy !== null && roomEnergy >= MINIMUM_WORKER_SPAWN_ENERGY;
 }
 function selectConstructionRecoveryCpuWorkerTask(creep) {
   var _a2;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28114,7 +28114,7 @@ function canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep) {
   var _a2;
   const carriedEnergy = getUsedEnergy2(creep);
   const roomEnergy = getRoomEnergyAvailable11(creep.room);
-  return carriedEnergy > 0 && getActiveWorkParts2(creep) > 0 && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !hasVisibleHostilePresence3(creep.room) && !shouldGuardControllerDowngrade2(creep.room.controller) && !hasActiveSpawningSpawn(creep.room) && !hasOtherSameRoomBuildCoverageWorker(creep) && roomEnergy !== null && roomEnergy - carriedEnergy >= MINIMUM_WORKER_SPAWN_ENERGY;
+  return carriedEnergy > 0 && getActiveWorkParts2(creep) > 0 && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !hasVisibleHostilePresence3(creep.room) && !shouldGuardControllerDowngrade2(creep.room.controller) && !hasActiveSpawningSpawn(creep.room) && !hasOtherSameRoomBuildCoverageWorker(creep) && roomEnergy !== null && roomEnergy >= MINIMUM_WORKER_SPAWN_ENERGY;
 }
 function selectConstructionRecoveryCpuWorkerTask(creep) {
   var _a2;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -620,7 +620,7 @@ function canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep: Creep): b
     !hasActiveSpawningSpawn(creep.room) &&
     !hasOtherSameRoomBuildCoverageWorker(creep) &&
     roomEnergy !== null &&
-    roomEnergy - carriedEnergy >= MINIMUM_WORKER_SPAWN_ENERGY
+    roomEnergy >= MINIMUM_WORKER_SPAWN_ENERGY
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -434,6 +434,16 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     });
   }
 
+  const energyStarvedSourceLogisticsConstructionTask =
+    selectEnergyStarvedSourceLogisticsConstructionRecoveryTask(
+      creep,
+      constructionSites,
+      constructionReservationContext
+    );
+  if (energyStarvedSourceLogisticsConstructionTask) {
+    return applyMinimumUsefulLoadPolicy(creep, energyStarvedSourceLogisticsConstructionTask);
+  }
+
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   const coveredLowBucketControllerProgressTask =
     controller && !priorityTowerEnergySink && shouldRunConstructionCpuWork(cpuBudget)
@@ -564,6 +574,54 @@ function selectNonCriticalCpuLoadedControllerProgressTask(
   return controller?.my === true && canUpgradeController(controller)
     ? { type: 'upgrade', targetId: controller.id }
     : null;
+}
+
+function selectEnergyStarvedSourceLogisticsConstructionRecoveryTask(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): Extract<CreepTaskMemory, { type: 'build' }> | null {
+  const constructionSite = selectEnergyStarvedSourceLogisticsConstructionRecoverySite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
+}
+
+function selectEnergyStarvedSourceLogisticsConstructionRecoverySite(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): ConstructionSite | null {
+  if (!canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep)) {
+    return null;
+  }
+
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    (site) => isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext),
+    { priorityContext, requireReasonableRange: true }
+  );
+}
+
+function canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep: Creep): boolean {
+  const carriedEnergy = getUsedEnergy(creep);
+  const roomEnergy = getRoomEnergyAvailable(creep.room);
+  return (
+    carriedEnergy > 0 &&
+    getActiveWorkParts(creep) > 0 &&
+    creep.room.controller?.my === true &&
+    !hasVisibleHostilePresence(creep.room) &&
+    !shouldGuardControllerDowngrade(creep.room.controller) &&
+    !hasActiveSpawningSpawn(creep.room) &&
+    !hasOtherSameRoomBuildCoverageWorker(creep) &&
+    roomEnergy !== null &&
+    roomEnergy - carriedEnergy >= MINIMUM_WORKER_SPAWN_ENERGY
+  );
 }
 
 function selectConstructionRecoveryCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
@@ -4892,10 +4950,27 @@ function isEnergyStarvationSourceLogisticsConstructionSite(
 
   const priority = getConstructionSiteImpactPriority(site, priorityContext);
   if (isContainerConstructionSite(site)) {
-    return priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer;
+    return (
+      priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer ||
+      isSourceAdjacentContainerConstructionSite(site, priorityContext)
+    );
   }
 
   return isRoadConstructionSite(site) && priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad;
+}
+
+function isSourceAdjacentContainerConstructionSite(
+  site: ConstructionSite,
+  priorityContext: ConstructionSiteImpactPriorityContext
+): boolean {
+  return (
+    isContainerConstructionSite(site) &&
+    Array.isArray(priorityContext.sources) &&
+    priorityContext.sources.some((source) => {
+      const range = getRangeBetweenRoomObjectPositions(site, source);
+      return range !== null && range <= 1;
+    })
+  );
 }
 
 function canSpendOnStoredProtectedSourceContainerConstruction(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -617,7 +617,7 @@ function canUseEnergyStarvedSourceLogisticsConstructionRecovery(creep: Creep): b
     creep.room.controller?.my === true &&
     !hasVisibleHostilePresence(creep.room) &&
     !shouldGuardControllerDowngrade(creep.room.controller) &&
-    !hasActiveSpawningSpawn(creep.room) &&
+    !isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep) &&
     !hasOtherSameRoomBuildCoverageWorker(creep) &&
     roomEnergy !== null &&
     roomEnergy >= MINIMUM_WORKER_SPAWN_ENERGY

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -16150,6 +16150,74 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('uses loaded E29N57 recovery energy on a post-claim source-container site before noncritical refill under low bucket', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          E29N57: {
+            colony: 'E29N55',
+            roomName: 'E29N57',
+            status: 'spawningWorkers',
+            claimedAt: 1,
+            updatedAt: 2,
+            workerTarget: 4
+          }
+        }
+      }
+    } as Partial<Memory>;
+    const source = makeSource('source1', 20, 20, 'E29N57');
+    const site = {
+      id: 'container-site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 1_279,
+      pos: makeRoomPosition(20, 21, 'E29N57')
+    } as ConstructionSite;
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 300, 0);
+    const extension = makeEnergySinkWithEnergy('extension1', 'extension' as StructureConstant, 71, 29);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 371,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure, extension as AnyOwnedStructure],
+      sources: [source],
+      structures: [spawn as unknown as AnyStructure, extension as unknown as AnyStructure]
+    });
+    const builder = {
+      name: 'worker-E29N57-loaded',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 16 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 34 : 0))
+      },
+      room
+    } as unknown as Creep;
+    const harvester = {
+      name: 'worker-E29N57-harvest',
+      memory: { role: 'worker', colony: 'E29N57', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 10 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 40 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Builder: builder, Harvester: harvester });
+    setGameObjectsById([site, spawn, extension, source], { rooms: { E29N57: room }, time: 2_482_130 });
+    setCpuBucket(618);
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
   it('does not tag fallback construction withdraws for targets without a store', () => {
     const source = makeSource('source1', 20, 20, 'E29N57');
     const site = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -16218,7 +16218,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'container-site1' });
   });
 
-  it('uses loaded source-container recovery energy when room energy is exactly the worker spawn reserve', () => {
+  it('uses loaded source-container recovery energy during active spawning when the worker spawn reserve is covered', () => {
     const source = makeSource('source1', 20, 20, 'E29N57');
     const site = {
       id: 'container-site1',
@@ -16231,7 +16231,8 @@ describe('selectWorkerTask', () => {
       'spawn1',
       'spawn' as StructureConstant,
       MINIMUM_WORKER_SPAWN_ENERGY,
-      TEST_FULL_SPAWN_ENERGY - MINIMUM_WORKER_SPAWN_ENERGY
+      TEST_FULL_SPAWN_ENERGY - MINIMUM_WORKER_SPAWN_ENERGY,
+      { spawning: { remainingTime: 25 } }
     );
     const controller = {
       id: 'controller1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -16218,6 +16218,54 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'container-site1' });
   });
 
+  it('uses loaded source-container recovery energy when room energy is exactly the worker spawn reserve', () => {
+    const source = makeSource('source1', 20, 20, 'E29N57');
+    const site = {
+      id: 'container-site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 1_279,
+      pos: makeRoomPosition(20, 21, 'E29N57')
+    } as ConstructionSite;
+    const spawn = makeEnergySinkWithEnergy(
+      'spawn1',
+      'spawn' as StructureConstant,
+      MINIMUM_WORKER_SPAWN_ENERGY,
+      TEST_FULL_SPAWN_ENERGY - MINIMUM_WORKER_SPAWN_ENERGY
+    );
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [spawn as unknown as AnyStructure]
+    });
+    const builder = {
+      name: 'worker-E29N57-loaded',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 16 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 34 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Builder: builder });
+    setGameObjectsById([site, spawn, source], { rooms: { E29N57: room }, time: 2_482_131 });
+    setCpuBucket(618);
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
   it('does not tag fallback construction withdraws for targets without a store', () => {
     const source = makeSource('source1', 20, 20, 'E29N57');
     const site = {


### PR DESCRIPTION
## Summary
- Preserve a bounded critical-CPU recovery path for loaded workers to spend carried energy on energy-starved source-logistics construction.
- Treat source-adjacent container construction as source-logistics recovery even when post-claim priority classification reports it through the post-claim path first.
- Add an E29N57-like regression for the post-#2007 live state where a loaded worker previously chose noncritical refill while the source-container site stayed stalled.

## Diagnosis
Post-#2007 official deploy succeeded, but postdeploy acceptance still failed only for E29N57. The durable workflow artifact and later controller capture showed E29N57 with workers present, no hostile evidence, room energy around 371/1800, CPU bucket around 600-750, one critical source-container site, and telemetry alternating between `energy_buffer_below_threshold`, `cpu_shed_assignment_skipped`, and `worker_assignment_gap` while `buildCarriedEnergy` and `buildProgress` stayed at zero.

Local reproduction showed the idle recovery/harvest path still exists, but a loaded E29N57 worker carrying safe recovery energy selected noncritical extension refill instead of the critical source-adjacent container site. The missing edge was classification/order: the post-claim source container did not reach the energy-starved source-logistics construction recovery path, so low-bucket CPU shedding could withhold the remaining worker and leave no build carrier.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

## Universal task Done gate

- [x] Task type: bugfix
- [x] Expected observable outcome / named deliverable: E29N57 low-bucket source-container recovery assigns a loaded safe worker to build instead of noncritical refill when source logistics construction is critical.
- [x] Non-goals / accepted substitutes: No official MMO deploy, no merge, no Tencent paid compute, and no global CPU-shed disable in this lane.
- [x] Verification evidence required before Done: Local prod typecheck passed; Jest passed 105 suites and 2529 tests; build passed; git diff check passed; GitHub prod-ci passed.
- [x] Project Evidence / Next action / Blocked by: Issue #1989 Project item is In progress with refreshed Evidence, Next action, and Blocked by fields; PR #2008 Project item is In review with refreshed Evidence, Next action, and Blocked by fields.
- [x] Post-merge/deploy/runtime proof: Fresh official E29N57 capture shows workerCount positive plus build, buildCarriedEnergy, buildProgress, upgrade, or energy-buffer recovery, without worker_assignment_gap or cpu_shed_assignment_skipped deadlock telemetry.
- [x] Named deliverable proof: PR #2008 commit 47483fd changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and generated `prod/dist/main.js`; no external named surface is part of this lane.

## Runtime acceptance after merge/deploy
Requires fresh official captures showing E29N57 `workerCount`/owned creeps remain positive and at least one of: `build > 0`, `buildCarriedEnergy > 0`, `buildProgress > 0`, `upgrade > 0`, energy buffer healthy/recovering, or a documented strategic hold whose telemetry is not `worker_assignment_gap` / `cpu_shed_assignment_skipped` deadlock.

Related to #1989
