### PR TITLE
[codex] Quarantine RL dead-state dataset samples

### DIFF
--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -48,6 +48,7 @@ DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON = "dead_state_runtime_sample"
 DEAD_STATE_ZERO_CREEP_REASON = "zero_owned_creeps"
 DEAD_STATE_RCL1_AFTER_STABLE_REASON = "rcl1_after_prior_stable_room"
 DEAD_STATE_OWNED_ROOM_COLLAPSE_REASON = "owned_room_count_collapsed"
+DEAD_STATE_SAMPLE_MARKER = "deadStateQuarantine"
 STABLE_ROOM_RCL_LEVEL = 4
 COLLAPSED_ROOM_RCL_LEVEL = 1
 STALE_CONSOLE_CAPTURE_SOURCE_AGE_HOURS = 24.0
@@ -656,6 +657,15 @@ def record_sort_key(record: ArtifactRecord) -> tuple[str, int, str, str]:
     )
 
 
+def dead_state_processing_sort_key(record: ArtifactRecord) -> tuple[int, datetime, str, tuple[str, int, str, str]]:
+    source_timestamp = record_source_timestamp(record)
+    tick = record.payload.get("tick")
+    tick_text = f"{tick:020}" if isinstance(tick, int) else str(tick)
+    if source_timestamp is None:
+        return (1, datetime.max.replace(tzinfo=timezone.utc), tick_text, record_sort_key(record))
+    return (0, source_timestamp, tick_text, record_sort_key(record))
+
+
 def filter_incomplete_derived_runtime_records(
     scan: ScanResult,
     *,
@@ -828,7 +838,7 @@ def filter_dead_state_runtime_records(
     prior_max_owned_room_count: int | None = None
     filtered_records: list[ArtifactRecord] = []
 
-    for record in scan.records:
+    for record in sorted(scan.records, key=dead_state_processing_sort_key):
         current_owned_room_count = record_owned_room_count(record)
         owned_room_count_collapsed = (
             prior_max_owned_room_count is not None
@@ -886,6 +896,7 @@ def prune_dead_state_runtime_record(
     total_owned_creeps = record_total_owned_creeps(record, rooms)
     kept_rooms: list[JsonObject] = []
     skipped_samples: list[JsonObject] = []
+    rooms_changed = False
     for room in rooms:
         room_name = room.get("roomName")
         if not isinstance(room_name, str) or not room_name:
@@ -911,18 +922,33 @@ def prune_dead_state_runtime_record(
             evidence.owned_room_collapse_samples += 1
             quarantine_reasons.append(DEAD_STATE_OWNED_ROOM_COLLAPSE_REASON)
 
-        if not quarantine_reasons or allow_recovery_dead_state_samples:
+        if not quarantine_reasons:
             kept_rooms.append(room)
+            continue
+        unique_reasons = list(dict.fromkeys(quarantine_reasons))
+        if allow_recovery_dead_state_samples:
+            kept_rooms.append(
+                room_with_dead_state_marker(
+                    room,
+                    quarantine_reasons=unique_reasons,
+                    controller_level=controller_level,
+                    owned_creeps=owned_creeps,
+                    total_owned_creeps=total_owned_creeps,
+                    prior_max_rcl=prior_max_rcl_by_room.get(room_name),
+                    owned_room_count_collapsed=owned_room_count_collapsed,
+                )
+            )
+            rooms_changed = True
             continue
 
         evidence.quarantined_dead_state_samples += 1
-        for reason in dict.fromkeys(quarantine_reasons):
+        for reason in unique_reasons:
             evidence.quarantine_reasons[reason] = evidence.quarantine_reasons.get(reason, 0) + 1
         skipped_samples.append(
             dead_state_skip_entry(
                 record,
                 room,
-                quarantine_reasons=list(dict.fromkeys(quarantine_reasons)),
+                quarantine_reasons=unique_reasons,
                 controller_level=controller_level,
                 owned_creeps=owned_creeps,
                 total_owned_creeps=total_owned_creeps,
@@ -932,7 +958,7 @@ def prune_dead_state_runtime_record(
             )
         )
 
-    if not skipped_samples:
+    if not skipped_samples and not rooms_changed:
         return record, []
     if not kept_rooms:
         return None, skipped_samples
@@ -948,6 +974,30 @@ def prune_dead_state_runtime_record(
         ),
         skipped_samples,
     )
+
+
+def room_with_dead_state_marker(
+    room: JsonObject,
+    *,
+    quarantine_reasons: Sequence[str],
+    controller_level: float | None,
+    owned_creeps: float | None,
+    total_owned_creeps: float | None,
+    prior_max_rcl: float | None,
+    owned_room_count_collapsed: bool,
+) -> JsonObject:
+    marked_room = dict(room)
+    marked_room[DEAD_STATE_SAMPLE_MARKER] = {
+        "classifier": "dead_state_runtime_quarantine",
+        "recoveryMode": True,
+        "reasons": list(quarantine_reasons),
+        "controllerLevel": controller_level,
+        "ownedCreeps": owned_creeps,
+        "totalOwnedCreeps": total_owned_creeps,
+        "priorMaxRcl": prior_max_rcl,
+        "ownedRoomCountCollapsed": owned_room_count_collapsed,
+    }
+    return marked_room
 
 
 def dead_state_skip_entry(
@@ -1320,20 +1370,22 @@ def build_tick_rows(
                 continue
 
             sample_id = build_sample_id(record, record_index, room_name)
-            rows.append(
-                {
-                    "type": "screeps-rl-tick-sample",
-                    "schemaVersion": SCHEMA_VERSION,
-                    "sampleId": sample_id,
-                    "botCommit": bot_commit,
-                    "source": build_row_source(record),
-                    "observation": build_observation(payload, room),
-                    "actionLabels": build_action_labels(room),
-                    "reward": build_reward(payload, room),
-                    "split": assign_split(sample_id, split_seed, eval_ratio_value),
-                    "safety": safety_notes(),
-                }
-            )
+            row = {
+                "type": "screeps-rl-tick-sample",
+                "schemaVersion": SCHEMA_VERSION,
+                "sampleId": sample_id,
+                "botCommit": bot_commit,
+                "source": build_row_source(record),
+                "observation": build_observation(payload, room),
+                "actionLabels": build_action_labels(room),
+                "reward": build_reward(payload, room),
+                "split": assign_split(sample_id, split_seed, eval_ratio_value),
+                "safety": safety_notes(),
+            }
+            dead_state_marker = room.get(DEAD_STATE_SAMPLE_MARKER)
+            if isinstance(dead_state_marker, dict):
+                row[DEAD_STATE_SAMPLE_MARKER] = dead_state_marker
+            rows.append(row)
             if len(rows) >= sample_limit:
                 return rows
     return rows

--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -44,6 +44,12 @@ DEFAULT_SAMPLE_LIMIT = 200
 DEFAULT_EVAL_RATIO = 0.2
 INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON = "incomplete_derived_runtime_summary"
 STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON = "stale_non_current_room_console_capture"
+DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON = "dead_state_runtime_sample"
+DEAD_STATE_ZERO_CREEP_REASON = "zero_owned_creeps"
+DEAD_STATE_RCL1_AFTER_STABLE_REASON = "rcl1_after_prior_stable_room"
+DEAD_STATE_OWNED_ROOM_COLLAPSE_REASON = "owned_room_count_collapsed"
+STABLE_ROOM_RCL_LEVEL = 4
+COLLAPSED_ROOM_RCL_LEVEL = 1
 STALE_CONSOLE_CAPTURE_SOURCE_AGE_HOURS = 24.0
 SKIPPED_FILE_LOG_LIMIT = 100
 SKIPPED_SAMPLE_LOG_LIMIT = 50
@@ -90,6 +96,19 @@ class ArtifactRecord:
 
 
 @dataclass
+class DeadStateQuarantineEvidence:
+    recovery_mode: bool = False
+    inspected_samples: int = 0
+    zero_creep_samples: int = 0
+    rcl1_samples: int = 0
+    owned_room_collapse_samples: int = 0
+    quarantined_dead_state_samples: int = 0
+    quarantine_reasons: dict[str, int] = field(default_factory=dict)
+    source_time_min: datetime | None = None
+    source_time_max: datetime | None = None
+
+
+@dataclass
 class ScanResult:
     input_paths: list[str]
     source_files: dict[str, SourceFile] = field(default_factory=dict)
@@ -97,6 +116,7 @@ class ScanResult:
     strategy_shadow_reports: list[JsonObject] = field(default_factory=list)
     skipped_files: list[JsonObject] = field(default_factory=list)
     skipped_samples: list[JsonObject] = field(default_factory=list)
+    dead_state_quarantine: DeadStateQuarantineEvidence = field(default_factory=DeadStateQuarantineEvidence)
     scanned_files: int = 0
 
     def skip(self, path: Path | str, reason: str, **details: Any) -> None:
@@ -636,10 +656,17 @@ def record_sort_key(record: ArtifactRecord) -> tuple[str, int, str, str]:
     )
 
 
-def filter_incomplete_derived_runtime_records(scan: ScanResult) -> None:
+def filter_incomplete_derived_runtime_records(
+    scan: ScanResult,
+    *,
+    allow_recovery_dead_state_samples: bool = False,
+) -> None:
     filtered_records: list[ArtifactRecord] = []
     for record in scan.records:
-        filtered_record, skipped_rooms = prune_incomplete_derived_runtime_record(record)
+        filtered_record, skipped_rooms = prune_incomplete_derived_runtime_record(
+            record,
+            allow_recovery_dead_state_samples=allow_recovery_dead_state_samples,
+        )
         if not skipped_rooms:
             filtered_records.append(record)
             continue
@@ -659,7 +686,11 @@ def filter_incomplete_derived_runtime_records(scan: ScanResult) -> None:
     scan.records = filtered_records
 
 
-def prune_incomplete_derived_runtime_record(record: ArtifactRecord) -> tuple[ArtifactRecord | None, list[str]]:
+def prune_incomplete_derived_runtime_record(
+    record: ArtifactRecord,
+    *,
+    allow_recovery_dead_state_samples: bool = False,
+) -> tuple[ArtifactRecord | None, list[str]]:
     if not is_derived_postdeploy_or_monitor_record(record):
         return record, []
 
@@ -672,7 +703,9 @@ def prune_incomplete_derived_runtime_record(record: ArtifactRecord) -> tuple[Art
     for room in rooms:
         if not isinstance(room, dict):
             continue
-        if derived_room_has_console_gate_fields(room):
+        if derived_room_has_console_gate_fields(room) or (
+            allow_recovery_dead_state_samples and room_has_dead_state_evidence(room)
+        ):
             kept_rooms.append(room)
             continue
         room_name = room.get("roomName")
@@ -693,6 +726,14 @@ def prune_incomplete_derived_runtime_record(record: ArtifactRecord) -> tuple[Art
             line_number=record.line_number,
         ),
         skipped_rooms,
+    )
+
+
+def room_has_dead_state_evidence(room: JsonObject) -> bool:
+    owned_creeps = room_owned_creep_count(room)
+    controller_level = room_controller_level(room)
+    return owned_creeps == 0 or (
+        controller_level is not None and controller_level <= COLLAPSED_ROOM_RCL_LEVEL
     )
 
 
@@ -774,6 +815,261 @@ def filter_stale_non_current_console_capture_records(
             filtered_records.append(filtered_record)
 
     scan.records = filtered_records
+
+
+def filter_dead_state_runtime_records(
+    scan: ScanResult,
+    *,
+    allow_recovery_dead_state_samples: bool = False,
+) -> None:
+    evidence = scan.dead_state_quarantine
+    evidence.recovery_mode = allow_recovery_dead_state_samples
+    prior_max_rcl_by_room: dict[str, float] = {}
+    prior_max_owned_room_count: int | None = None
+    filtered_records: list[ArtifactRecord] = []
+
+    for record in scan.records:
+        current_owned_room_count = record_owned_room_count(record)
+        owned_room_count_collapsed = (
+            prior_max_owned_room_count is not None
+            and current_owned_room_count is not None
+            and current_owned_room_count < prior_max_owned_room_count
+        )
+        filtered_record, skipped_samples = prune_dead_state_runtime_record(
+            record,
+            prior_max_rcl_by_room=prior_max_rcl_by_room,
+            owned_room_count_collapsed=owned_room_count_collapsed,
+            allow_recovery_dead_state_samples=allow_recovery_dead_state_samples,
+            evidence=evidence,
+        )
+        scan.skipped_samples.extend(skipped_samples)
+        if filtered_record is not None:
+            filtered_records.append(filtered_record)
+
+        if current_owned_room_count is not None:
+            prior_max_owned_room_count = (
+                current_owned_room_count
+                if prior_max_owned_room_count is None
+                else max(prior_max_owned_room_count, current_owned_room_count)
+            )
+        for room in record_rooms(record):
+            room_name = room.get("roomName")
+            if not isinstance(room_name, str) or not room_name:
+                continue
+            controller_level = room_controller_level(room)
+            if controller_level is None:
+                continue
+            prior_max_rcl_by_room[room_name] = max(
+                prior_max_rcl_by_room.get(room_name, controller_level),
+                controller_level,
+            )
+
+    scan.records = filtered_records
+
+
+def prune_dead_state_runtime_record(
+    record: ArtifactRecord,
+    *,
+    prior_max_rcl_by_room: dict[str, float],
+    owned_room_count_collapsed: bool,
+    allow_recovery_dead_state_samples: bool,
+    evidence: DeadStateQuarantineEvidence,
+) -> tuple[ArtifactRecord | None, list[JsonObject]]:
+    rooms = record_rooms(record)
+    if not rooms:
+        return record, []
+
+    source_timestamp = record_source_timestamp(record)
+    if source_timestamp is not None:
+        update_dead_state_source_range(evidence, source_timestamp)
+
+    total_owned_creeps = record_total_owned_creeps(record, rooms)
+    kept_rooms: list[JsonObject] = []
+    skipped_samples: list[JsonObject] = []
+    for room in rooms:
+        room_name = room.get("roomName")
+        if not isinstance(room_name, str) or not room_name:
+            kept_rooms.append(room)
+            continue
+
+        evidence.inspected_samples += 1
+        controller_level = room_controller_level(room)
+        owned_creeps = room_owned_creep_count(room)
+        zero_creeps = owned_creeps == 0 or (owned_creeps is None and total_owned_creeps == 0)
+        rcl1_or_lower = controller_level is not None and controller_level <= COLLAPSED_ROOM_RCL_LEVEL
+        prior_stable_room = prior_max_rcl_by_room.get(room_name, 0) >= STABLE_ROOM_RCL_LEVEL
+        quarantine_reasons: list[str] = []
+
+        if zero_creeps:
+            evidence.zero_creep_samples += 1
+            quarantine_reasons.append(DEAD_STATE_ZERO_CREEP_REASON)
+        if rcl1_or_lower:
+            evidence.rcl1_samples += 1
+            if prior_stable_room or owned_room_count_collapsed:
+                quarantine_reasons.append(DEAD_STATE_RCL1_AFTER_STABLE_REASON)
+        if owned_room_count_collapsed:
+            evidence.owned_room_collapse_samples += 1
+            quarantine_reasons.append(DEAD_STATE_OWNED_ROOM_COLLAPSE_REASON)
+
+        if not quarantine_reasons or allow_recovery_dead_state_samples:
+            kept_rooms.append(room)
+            continue
+
+        evidence.quarantined_dead_state_samples += 1
+        for reason in dict.fromkeys(quarantine_reasons):
+            evidence.quarantine_reasons[reason] = evidence.quarantine_reasons.get(reason, 0) + 1
+        skipped_samples.append(
+            dead_state_skip_entry(
+                record,
+                room,
+                quarantine_reasons=list(dict.fromkeys(quarantine_reasons)),
+                controller_level=controller_level,
+                owned_creeps=owned_creeps,
+                total_owned_creeps=total_owned_creeps,
+                source_timestamp=source_timestamp,
+                prior_max_rcl=prior_max_rcl_by_room.get(room_name),
+                owned_room_count_collapsed=owned_room_count_collapsed,
+            )
+        )
+
+    if not skipped_samples:
+        return record, []
+    if not kept_rooms:
+        return None, skipped_samples
+
+    payload = dict(record.payload)
+    payload["rooms"] = kept_rooms
+    return (
+        ArtifactRecord(
+            source=record.source,
+            artifact_kind=record.artifact_kind,
+            payload=payload,
+            line_number=record.line_number,
+        ),
+        skipped_samples,
+    )
+
+
+def dead_state_skip_entry(
+    record: ArtifactRecord,
+    room: JsonObject,
+    *,
+    quarantine_reasons: Sequence[str],
+    controller_level: float | None,
+    owned_creeps: float | None,
+    total_owned_creeps: float | None,
+    source_timestamp: datetime | None,
+    prior_max_rcl: float | None,
+    owned_room_count_collapsed: bool,
+) -> JsonObject:
+    return {
+        "reason": DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON,
+        "deadStateReasons": list(quarantine_reasons),
+        "path": record.source.display_path,
+        "artifactKind": record.artifact_kind,
+        "lineNumber": record.line_number,
+        "tick": number_or_none(record.payload.get("tick")),
+        "roomName": room.get("roomName") if isinstance(room.get("roomName"), str) else None,
+        "sourceTimestamp": isoformat_utc(source_timestamp) if source_timestamp is not None else None,
+        "controllerLevel": controller_level,
+        "ownedCreeps": owned_creeps,
+        "totalOwnedCreeps": total_owned_creeps,
+        "priorMaxRcl": prior_max_rcl,
+        "ownedRoomCountCollapsed": owned_room_count_collapsed,
+        "samplesEligibleForTraining": False,
+    }
+
+
+def record_rooms(record: ArtifactRecord) -> list[JsonObject]:
+    rooms = record.payload.get("rooms")
+    if not isinstance(rooms, list):
+        return []
+    return [room for room in rooms if isinstance(room, dict)]
+
+
+def record_owned_room_count(record: ArtifactRecord) -> int | None:
+    payload = record.payload
+    direct = first_number(
+        (
+            nested_get(payload, ("territory", "ownedRoomCount")),
+            nested_get(payload, ("territory", "ownedRooms")),
+            payload.get("ownedRoomCount"),
+            payload.get("ownedRooms"),
+            payload.get("owned_room_count"),
+            payload.get("owned_rooms"),
+        )
+    )
+    if direct is not None:
+        return max(0, int(direct))
+    owned_rooms = nested_get(payload, ("territory", "ownedRooms"))
+    if isinstance(owned_rooms, list):
+        return len([room for room in owned_rooms if isinstance(room, str) and room])
+    rooms = record_rooms(record)
+    if rooms:
+        return len(
+            [
+                room
+                for room in rooms
+                if isinstance(room.get("roomName"), str) and room.get("roomName")
+            ]
+        )
+    return None
+
+
+def record_total_owned_creeps(record: ArtifactRecord, rooms: Sequence[JsonObject]) -> float | None:
+    direct = first_number(
+        (
+            record.payload.get("ownedCreeps"),
+            record.payload.get("ownedCreepCount"),
+            record.payload.get("totalOwnedCreeps"),
+            record.payload.get("total_owned_creeps"),
+            nested_get(record.payload, ("creeps", "owned")),
+            nested_get(record.payload, ("creeps", "ownedCount")),
+            nested_get(record.payload, ("workers", "count")),
+        )
+    )
+    if direct is not None:
+        return direct
+
+    counts = [room_owned_creep_count(room) for room in rooms]
+    numeric_counts = [count for count in counts if count is not None]
+    if numeric_counts and len(numeric_counts) == len(rooms):
+        return sum(numeric_counts)
+    return None
+
+
+def room_owned_creep_count(room: JsonObject) -> float | None:
+    return first_number(
+        (
+            room.get("workerCount"),
+            room.get("ownedCreeps"),
+            room.get("ownedCreepCount"),
+            room.get("creeps"),
+            room.get("owned_creeps"),
+            nested_get(room, ("workers", "count")),
+            nested_get(room, ("workerAssignmentEvidence", "workerCount")),
+            nested_get(room, ("workerAssignmentEvidence", "visibleCreepCount")),
+            nested_get(room, ("resources", "productiveEnergy", "assignedWorkerCount")),
+        )
+    )
+
+
+def room_controller_level(room: JsonObject) -> float | None:
+    return first_number(
+        (
+            nested_get(room, ("controller", "level")),
+            room.get("rclLevel"),
+            room.get("controllerLevel"),
+            room.get("rcl"),
+        )
+    )
+
+
+def update_dead_state_source_range(evidence: DeadStateQuarantineEvidence, source_timestamp: datetime) -> None:
+    if evidence.source_time_min is None or source_timestamp < evidence.source_time_min:
+        evidence.source_time_min = source_timestamp
+    if evidence.source_time_max is None or source_timestamp > evidence.source_time_max:
+        evidence.source_time_max = source_timestamp
 
 
 def prune_stale_non_current_console_capture_record(
@@ -909,6 +1205,7 @@ def build_dataset(
     created_at: str | None = None,
     home_room: str | None = None,
     source_max_age_hours: float | None = None,
+    allow_recovery_dead_state_samples: bool = False,
 ) -> JsonObject:
     repo = repo_root or Path.cwd()
     resolved_bot_commit = bot_commit or git_commit(repo)
@@ -921,8 +1218,15 @@ def build_dataset(
         max_age_hours=source_max_age_hours,
         excluded_directory_names=GENERATED_ARTIFACT_DIRECTORY_NAMES,
     )
-    filter_incomplete_derived_runtime_records(scan)
     filter_stale_non_current_console_capture_records(scan, home_room=resolved_home_room, created_at=created_at)
+    filter_dead_state_runtime_records(
+        scan,
+        allow_recovery_dead_state_samples=allow_recovery_dead_state_samples,
+    )
+    filter_incomplete_derived_runtime_records(
+        scan,
+        allow_recovery_dead_state_samples=allow_recovery_dead_state_samples,
+    )
     rows = build_tick_rows(scan.records, resolved_bot_commit, sample_limit, eval_ratio_value, split_seed)
     resolved_run_id = run_id or deterministic_run_id(scan, rows, resolved_bot_commit, sample_limit, eval_ratio_value, split_seed)
     validate_run_id(resolved_run_id)
@@ -940,7 +1244,7 @@ def build_dataset(
 
     runtime_lines = runtime_lines_from_records(scan.records)
     kpi_windows = reducer.reduce_runtime_kpis(runtime_lines)
-    source_index = build_source_index(scan, source_max_age_hours=source_max_age_hours)
+    source_index = build_source_index(scan, source_max_age_hours=source_max_age_hours, eligible_sample_count=len(rows))
     split_counts = count_splits(rows)
     scenario_manifest = build_scenario_manifest(resolved_run_id, scan, resolved_bot_commit)
     episodes = build_episodes(resolved_run_id, rows, kpi_windows)
@@ -991,6 +1295,7 @@ def build_dataset(
         "skippedFileReasons": count_skipped_file_field(scan, "reason"),
         **optional_source_max_age(source_max_age_hours),
         **build_skipped_sample_summary(scan),
+        "deadStateQuarantine": build_dead_state_quarantine_summary(scan, eligible_sample_count=len(rows)),
         "splitCounts": split_counts,
         "files": files,
     }
@@ -1317,6 +1622,37 @@ def build_skipped_sample_summary(scan: ScanResult) -> JsonObject:
     }
 
 
+def build_dead_state_quarantine_summary(scan: ScanResult, *, eligible_sample_count: int) -> JsonObject:
+    evidence = scan.dead_state_quarantine
+    quarantined = evidence.quarantined_dead_state_samples
+    samples_remain_eligible = eligible_sample_count > 0
+    if evidence.recovery_mode:
+        eligibility = "recovery_mode_dataset"
+    elif quarantined > 0 and samples_remain_eligible:
+        eligibility = "eligible_samples_remain_after_quarantine"
+    elif quarantined > 0:
+        eligibility = "blocked_no_eligible_samples_after_quarantine"
+    else:
+        eligibility = "standard_training_dataset"
+
+    return {
+        "recovery_mode": evidence.recovery_mode,
+        "inspected_samples": evidence.inspected_samples,
+        "quarantined_dead_state_samples": quarantined,
+        "zero_creep_samples": evidence.zero_creep_samples,
+        "rcl1_samples": evidence.rcl1_samples,
+        "owned_room_collapse_samples": evidence.owned_room_collapse_samples,
+        "quarantine_reasons": dict(sorted(evidence.quarantine_reasons.items())),
+        "source_time_range": {
+            "min": isoformat_utc(evidence.source_time_min) if evidence.source_time_min is not None else None,
+            "max": isoformat_utc(evidence.source_time_max) if evidence.source_time_max is not None else None,
+        },
+        "eligible_sample_count": eligible_sample_count,
+        "samples_remain_eligible_for_training": samples_remain_eligible,
+        "training_eligibility": eligibility,
+    }
+
+
 def build_skipped_file_summary(scan: ScanResult) -> JsonObject:
     skipped_files = sorted_skipped_files(scan)
     return {
@@ -1368,7 +1704,12 @@ def optional_source_max_age(source_max_age_hours: float | None) -> JsonObject:
     return {"sourceMaxAgeHours": source_max_age_hours}
 
 
-def build_source_index(scan: ScanResult, *, source_max_age_hours: float | None = None) -> JsonObject:
+def build_source_index(
+    scan: ScanResult,
+    *,
+    source_max_age_hours: float | None = None,
+    eligible_sample_count: int = 0,
+) -> JsonObject:
     skipped_file_summary = build_skipped_file_summary(scan)
     skipped_sample_summary = build_skipped_sample_summary(scan)
     return {
@@ -1391,6 +1732,7 @@ def build_source_index(scan: ScanResult, *, source_max_age_hours: float | None =
         "strategyShadowReports": scan.strategy_shadow_reports,
         **skipped_file_summary,
         **skipped_sample_summary,
+        "deadStateQuarantine": build_dead_state_quarantine_summary(scan, eligible_sample_count=eligible_sample_count),
     }
 
 
@@ -1494,6 +1836,7 @@ def build_run_manifest(
             "skippedFileCount": len(scan.skipped_files),
             "skippedFileReasons": count_skipped_file_field(scan, "reason"),
             **build_skipped_sample_summary(scan),
+            "deadStateQuarantine": build_dead_state_quarantine_summary(scan, eligible_sample_count=len(rows)),
         },
         "strategy": {
             "registryPath": "prod/src/strategy/strategyRegistry.ts",
@@ -1528,6 +1871,7 @@ def render_dataset_card(run_id: str, run_manifest: JsonObject, episodes: list[Js
     source = run_manifest["source"]
     split = run_manifest["split"]
     strategy = run_manifest["strategy"]
+    dead_state = source.get("deadStateQuarantine") if isinstance(source.get("deadStateQuarantine"), dict) else {}
     episode = episodes[0] if episodes else {}
     rooms = ", ".join(episode.get("rooms", [])) if isinstance(episode.get("rooms"), list) else "none"
     surfaces = ", ".join(strategy["decisionSurfacesObserved"]) or "none observed"
@@ -1546,6 +1890,11 @@ def render_dataset_card(run_id: str, run_manifest: JsonObject, episodes: list[Js
             f"- Matched runtime/monitor artifacts: {source['matchedArtifactCount']}",
             f"- Scanned files: {source['scannedFiles']}",
             f"- Rooms: {rooms or 'none'}",
+            (
+                "- Dead-state quarantine: "
+                f"{dead_state.get('quarantined_dead_state_samples', 0)} quarantined; "
+                f"training eligibility {dead_state.get('training_eligibility', 'unknown')}."
+            ),
             "",
             "## Schema",
             "",
@@ -1745,6 +2094,14 @@ def build_parser() -> argparse.ArgumentParser:
             f"Default: {CONSOLE_CAPTURE_MAX_AGE_HOURS:g} in --console-capture-only mode, otherwise unbounded."
         ),
     )
+    parser.add_argument(
+        "--allow-recovery-dead-state-samples",
+        action="store_true",
+        help=(
+            "Keep zero-creep/RCL1/collapsed-owned-room samples for an explicit recovery-mode dataset. "
+            "By default these live runtime samples are quarantined out of ordinary training datasets."
+        ),
+    )
     return parser
 
 
@@ -1772,6 +2129,7 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
         eval_ratio_value=args.eval_ratio,
         split_seed=args.split_seed,
         source_max_age_hours=source_max_age_hours,
+        allow_recovery_dead_state_samples=args.allow_recovery_dead_state_samples,
     )
     stdout.write(json.dumps(summary, indent=2, sort_keys=True))
     stdout.write("\n")

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -483,11 +483,13 @@ def quality_rejection_reasons(
 
 
 def sample_has_dead_state_evidence(sample: JsonObject, evidence: JsonObject | None = None) -> bool:
-    resolved_evidence = evidence if isinstance(evidence, dict) else quality_evidence(sample)
-    observation = sample.get("observation") if isinstance(sample.get("observation"), dict) else {}
-    controller_level = number_at_path(observation, ("controller", "level"))
-    owned_creeps = finite_number(resolved_evidence.get("ownedCreeps"))
-    return owned_creeps == 0 or (controller_level is not None and controller_level <= 1)
+    marker = sample.get(dataset_export.DEAD_STATE_SAMPLE_MARKER)
+    if not isinstance(marker, dict):
+        return False
+    reasons = marker.get("reasons")
+    if isinstance(reasons, list) and any(isinstance(reason, str) and reason for reason in reasons):
+        return True
+    return marker.get("ownedRoomCountCollapsed") is True
 
 
 def missing_quality_telemetry(evidence: JsonObject) -> bool:

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -135,8 +135,10 @@ def default_gate_id(
     baseline_kpi: Path | None,
     current_kpi: Path | None,
     bot_commit: str,
+    allow_recovery_dead_state_samples: bool = False,
 ) -> str:
     seed = {
+        "allowRecoveryDeadStateSamples": allow_recovery_dead_state_samples,
         "baselineKpi": dataset_export.display_path(baseline_kpi) if baseline_kpi else None,
         "botCommit": bot_commit,
         "candidateConfig": dataset_export.display_path(candidate_config) if candidate_config else None,
@@ -189,6 +191,15 @@ def build_contract() -> JsonObject:
                 "default": DEFAULT_HOME_ROOM,
                 "contract": "only the configured home room is expected to have owned spawns",
             },
+            "recoveryDeadStateSamples": {
+                "flag": "--allow-recovery-dead-state-samples",
+                "required": False,
+                "default": False,
+                "contract": (
+                    "ordinary gates quarantine zero-creep, RCL1-after-stable, or owned-room-collapse live "
+                    "runtime samples; this flag keeps them only for explicit recovery-mode datasets"
+                ),
+            },
             "conclusionRegistry": {
                 "flag": "--conclusion-registry",
                 "required": False,
@@ -215,6 +226,10 @@ def build_contract() -> JsonObject:
         "gateChecks": {
             "dataset": "dataset run exists, has at least the configured sample count, has manifest/source/tick/KPI files, and preserves offline safety flags",
             "qualityChecks": "dataset samples must show active harvest/upgrade work, room energy, owned creeps, and home-room owned spawns; non-home rooms may have no owned spawns",
+            "deadStateQuarantine": (
+                "ordinary training datasets must quarantine live runtime samples with zero owned creeps, "
+                "RCL <= 1 after prior stable/collapse evidence, or owned-room-count collapse"
+            ),
             "shadowEvaluation": "strategy-shadow report generation succeeds unless explicitly skipped",
             "historicalValidation": "candidate report must pass when --candidate-config is supplied",
             "predefinedMetrics": (
@@ -424,9 +439,16 @@ def quality_evidence(sample: JsonObject) -> JsonObject:
     }
 
 
-def quality_rejection_reasons(sample: JsonObject, *, home_room: str | None = None) -> list[str]:
+def quality_rejection_reasons(
+    sample: JsonObject,
+    *,
+    home_room: str | None = None,
+    recovery_mode: bool = False,
+) -> list[str]:
     resolved_home_room = home_room or configured_home_room()
     evidence = quality_evidence(sample)
+    if recovery_mode and sample_has_dead_state_evidence(sample, evidence):
+        return []
     room_name = sample_room_name(sample)
     reasons: list[str] = []
     room_energy_present = (
@@ -458,6 +480,14 @@ def quality_rejection_reasons(sample: JsonObject, *, home_room: str | None = Non
     if room_name == resolved_home_room and not positive_value(evidence["ownedSpawns"]):
         reasons.append("no_owned_spawns")
     return reasons
+
+
+def sample_has_dead_state_evidence(sample: JsonObject, evidence: JsonObject | None = None) -> bool:
+    resolved_evidence = evidence if isinstance(evidence, dict) else quality_evidence(sample)
+    observation = sample.get("observation") if isinstance(sample.get("observation"), dict) else {}
+    controller_level = number_at_path(observation, ("controller", "level"))
+    owned_creeps = finite_number(resolved_evidence.get("ownedCreeps"))
+    return owned_creeps == 0 or (controller_level is not None and controller_level <= 1)
 
 
 def missing_quality_telemetry(evidence: JsonObject) -> bool:
@@ -581,7 +611,13 @@ def build_quality_tail_classification(
     }
 
 
-def evaluate_quality_checks(ticks_path: Path, *, home_room: str | None = None, created_at: str | None = None) -> JsonObject:
+def evaluate_quality_checks(
+    ticks_path: Path,
+    *,
+    home_room: str | None = None,
+    created_at: str | None = None,
+    recovery_mode: bool = False,
+) -> JsonObject:
     resolved_home_room = home_room or configured_home_room()
     samples_accepted = 0
     samples_rejected = 0
@@ -626,7 +662,11 @@ def evaluate_quality_checks(ticks_path: Path, *, home_room: str | None = None, c
                 reasons = ["invalid_sample_json"]
             else:
                 reasons = (
-                    quality_rejection_reasons(sample, home_room=resolved_home_room)
+                    quality_rejection_reasons(
+                        sample,
+                        home_room=resolved_home_room,
+                        recovery_mode=recovery_mode,
+                    )
                     if isinstance(sample, dict)
                     else ["invalid_sample_json"]
                 )
@@ -720,6 +760,7 @@ def evaluate_quality_checks(ticks_path: Path, *, home_room: str | None = None, c
         "rejected_sample_log_limit": QUALITY_REJECTED_SAMPLE_LOG_LIMIT,
         "rejected_samples_truncated": max(0, samples_rejected - len(rejected_samples)),
         "home_room": resolved_home_room,
+        "recovery_mode": recovery_mode,
         "checks": checks,
     }
 
@@ -899,6 +940,11 @@ def dataset_source_diagnostics(
     min_samples: int,
 ) -> JsonObject:
     source = run_manifest.get("source") if isinstance(run_manifest.get("source"), dict) else {}
+    dead_state_quarantine = (
+        dataset_summary.get("deadStateQuarantine")
+        if isinstance(dataset_summary.get("deadStateQuarantine"), dict)
+        else source.get("deadStateQuarantine") if isinstance(source.get("deadStateQuarantine"), dict) else {}
+    )
     input_paths = source.get("inputPaths") if isinstance(source.get("inputPaths"), list) else []
     source_artifact_count = dataset_summary.get("sourceArtifactCount")
     runtime_summary_count = dataset_summary.get("runtimeSummaryArtifactCount")
@@ -914,6 +960,7 @@ def dataset_source_diagnostics(
             "status": "pass",
             "classification": "sample_floor_satisfied",
             "inputPaths": input_paths,
+            "deadStateQuarantine": dead_state_quarantine,
         }
 
     sample_cadence = build_runtime_sample_cadence_diagnostics(
@@ -942,17 +989,25 @@ def dataset_source_diagnostics(
             "Point the full E1 gate at runtime-summary source artifacts, such as "
             "runtime-artifacts/runtime-summary-console, instead of an empty or generated gate-data directory."
         )
+    elif isinstance(skipped_sample_count, int) and skipped_sample_count > 0 and sample_count == 0:
+        quarantined_dead_state = dead_state_quarantine.get("quarantined_dead_state_samples")
+        if isinstance(quarantined_dead_state, int) and quarantined_dead_state > 0:
+            classification = "all_runtime_samples_quarantined_dead_state"
+            recommended_action = (
+                "Collect post-recovery runtime summaries before using this ordinary E1 training gate, "
+                "or rerun with --allow-recovery-dead-state-samples only for an explicit recovery-mode dataset."
+            )
+        else:
+            classification = "all_runtime_samples_filtered"
+            recommended_action = (
+                "Refresh or narrow the runtime-summary source window so the full gate has current samples "
+                "for the configured home room."
+            )
     elif runtime_summary_count == 0:
         classification = "no_runtime_summary_artifacts"
         recommended_action = (
             "Use the same runtime-summary console source window that feeds the passing E1-lite gate; "
             "generated gate-data and dataset directories are outputs, not full-gate input evidence."
-        )
-    elif isinstance(skipped_sample_count, int) and skipped_sample_count > 0 and sample_count == 0:
-        classification = "all_runtime_samples_filtered"
-        recommended_action = (
-            "Refresh or narrow the runtime-summary source window so the full gate has current samples "
-            "for the configured home room."
         )
     else:
         classification = "insufficient_runtime_samples"
@@ -987,6 +1042,7 @@ def dataset_source_diagnostics(
         "skippedFileReasons": skipped_file_reasons,
         "skippedSampleCount": skipped_sample_count,
         "skippedSampleReasons": skipped_sample_reasons,
+        "deadStateQuarantine": dead_state_quarantine,
         "sampleCadence": sample_cadence,
     }
 
@@ -1010,6 +1066,11 @@ def evaluate_dataset_readiness(
         run_manifest,
         sample_count=sample_count,
         min_samples=min_samples,
+    )
+    dead_state_quarantine = (
+        dataset_summary.get("deadStateQuarantine")
+        if isinstance(dataset_summary.get("deadStateQuarantine"), dict)
+        else diagnostics.get("deadStateQuarantine") if isinstance(diagnostics.get("deadStateQuarantine"), dict) else {}
     )
     files_to_check = ("scenarioManifest", "runManifest", "sourceIndex", "ticks", "kpiWindows", "episodes", "datasetCard")
     checks: list[JsonObject] = [
@@ -1067,6 +1128,7 @@ def evaluate_dataset_readiness(
         "strategyShadowReportCount": dataset_summary.get("strategyShadowReportCount"),
         "skippedSampleCount": dataset_summary.get("skippedSampleCount"),
         "skippedSampleReasons": dataset_summary.get("skippedSampleReasons"),
+        "deadStateQuarantine": dead_state_quarantine,
         "splitCounts": dataset_summary.get("splitCounts"),
         "runId": dataset_summary.get("runId"),
         "runDir": dataset_export.display_path(file_paths["runDir"]),
@@ -1407,6 +1469,11 @@ def collect_blocking_reasons(report: JsonObject) -> list[JsonObject]:
 def build_summary(report: JsonObject) -> JsonObject:
     dataset_gate = report.get("datasetGate") if isinstance(report.get("datasetGate"), dict) else {}
     dataset = report.get("dataset") if isinstance(report.get("dataset"), dict) else {}
+    dead_state = (
+        dataset_gate.get("deadStateQuarantine")
+        if isinstance(dataset_gate.get("deadStateQuarantine"), dict)
+        else dataset.get("deadStateQuarantine") if isinstance(dataset.get("deadStateQuarantine"), dict) else {}
+    )
     quality = report.get("quality_checks") if isinstance(report.get("quality_checks"), dict) else {}
     shadow = report.get("shadowEvaluation") if isinstance(report.get("shadowEvaluation"), dict) else {}
     historical = report.get("historicalValidation") if isinstance(report.get("historicalValidation"), dict) else {}
@@ -1422,6 +1489,7 @@ def build_summary(report: JsonObject) -> JsonObject:
         "datasetRunId": dataset.get("runId"),
         "datasetPath": dataset.get("outDir"),
         "sampleCount": dataset_gate.get("sampleCount"),
+        "deadStateQuarantine": dead_state,
         "qualityChecksStatus": quality.get("status"),
         "samplesAccepted": quality.get("samples_accepted"),
         "samplesRejected": quality.get("samples_rejected"),
@@ -1631,6 +1699,7 @@ def run_gate(
     min_owned_rooms: float | None = None,
     min_resource_score: float | None = None,
     min_kills_score: float | None = None,
+    allow_recovery_dead_state_samples: bool = False,
     conclusion_registry_path: Path | None = None,
     repo_root: Path | None = None,
 ) -> JsonObject:
@@ -1647,6 +1716,7 @@ def run_gate(
         baseline_kpi=baseline_kpi,
         current_kpi=current_kpi,
         bot_commit=resolved_bot_commit,
+        allow_recovery_dead_state_samples=allow_recovery_dead_state_samples,
     )
     validate_gate_id(resolved_gate_id)
 
@@ -1692,6 +1762,7 @@ def run_gate(
         repo_root=repo,
         created_at=created,
         home_room=resolved_home_room,
+        allow_recovery_dead_state_samples=allow_recovery_dead_state_samples,
     )
     file_paths = dataset_file_paths(resolved_dataset_out_dir, str(dataset_summary["runId"]), dataset_summary["files"])
     run_manifest = load_json(file_paths["runManifest"])
@@ -1706,7 +1777,12 @@ def run_gate(
         ticks_count,
         min_samples=min_samples,
     )
-    quality_checks = evaluate_quality_checks(file_paths["ticks"], home_room=resolved_home_room, created_at=created)
+    quality_checks = evaluate_quality_checks(
+        file_paths["ticks"],
+        home_room=resolved_home_room,
+        created_at=created,
+        recovery_mode=allow_recovery_dead_state_samples,
+    )
     floors = metric_floors(
         min_reliability=min_reliability,
         min_owned_rooms=min_owned_rooms,
@@ -1752,6 +1828,7 @@ def run_gate(
             "baselineKpi": dataset_export.display_path(baseline_kpi) if baseline_kpi is not None else None,
             "currentKpi": dataset_export.display_path(current_kpi_path),
             "botCommit": resolved_bot_commit,
+            "allowRecoveryDeadStateSamples": allow_recovery_dead_state_samples,
         },
         "dataset": dataset_summary,
         "datasetGate": dataset_gate,
@@ -1862,6 +1939,14 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--min-resource-score", type=non_negative_number, help="Optional current resource-score floor.")
     run.add_argument("--min-kills-score", type=non_negative_number, help="Optional current kills-score floor.")
     run.add_argument(
+        "--allow-recovery-dead-state-samples",
+        action="store_true",
+        help=(
+            "Keep zero-creep/RCL1/collapsed-owned-room samples for an explicit recovery-mode dataset. "
+            "Ordinary E1 gates quarantine them before training eligibility."
+        ),
+    )
+    run.add_argument(
         "--conclusion-registry",
         type=Path,
         help=(
@@ -1900,6 +1985,7 @@ def cli_failure_gate_id(args: argparse.Namespace, repo: Path, created_at: str) -
         baseline_kpi=getattr(args, "baseline_kpi", None),
         current_kpi=getattr(args, "current_kpi", None),
         bot_commit=bot_commit,
+        allow_recovery_dead_state_samples=bool(getattr(args, "allow_recovery_dead_state_samples", False)),
     )
 
 
@@ -1962,6 +2048,7 @@ def build_cli_failure_report(
             if getattr(args, "current_kpi", None) is not None
             else None,
             "botCommit": bot_commit,
+            "allowRecoveryDeadStateSamples": bool(getattr(args, "allow_recovery_dead_state_samples", False)),
         },
         "datasetGate": {
             "status": "fail",
@@ -2097,6 +2184,7 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
                 min_owned_rooms=args.min_owned_rooms,
                 min_resource_score=args.min_resource_score,
                 min_kills_score=args.min_kills_score,
+                allow_recovery_dead_state_samples=args.allow_recovery_dead_state_samples,
                 conclusion_registry_path=args.conclusion_registry,
                 repo_root=args.repo_root,
             )

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -566,6 +566,43 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertFalse(skipped_sample["samplesEligibleForTraining"])
         self.assertEqual(run_manifest["source"]["deadStateQuarantine"], quarantine)
 
+    def test_dead_state_quarantine_uses_source_timestamp_before_path_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            stable_artifact = root / "z-stable" / "runtime-summary-console-20260624T115900Z.log"
+            dead_artifact = root / "a-dead" / "runtime-summary-console-20260624T131214Z.log"
+            stable_artifact.parent.mkdir(parents=True)
+            dead_artifact.parent.mkdir(parents=True)
+            stable_artifact.write_text(runtime_line(active_runtime_payload(2558700, rcl=4)), encoding="utf-8")
+            dead_artifact.write_text(runtime_line(active_runtime_payload(2560700, rcl=1)), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(root)],
+                out_dir,
+                run_id="dead-state-chronological-run",
+                bot_commit="8" * 40,
+                eval_ratio_value=0,
+                created_at="2026-06-24T16:30:00Z",
+                home_room="E29N55",
+            )
+            rows = read_ndjson(out_dir / "dead-state-chronological-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "dead-state-chronological-run" / "source_index.json")
+
+        quarantine = summary["deadStateQuarantine"]
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(rows[0]["observation"]["controller"]["level"], 4)
+        self.assertEqual(summary["skippedSampleCount"], 1)
+        self.assertEqual(quarantine["quarantined_dead_state_samples"], 1)
+        self.assertEqual(quarantine["zero_creep_samples"], 0)
+        self.assertEqual(quarantine["rcl1_samples"], 1)
+        skipped_sample = source_index["skippedSamples"][0]
+        self.assertEqual(
+            skipped_sample["deadStateReasons"],
+            [exporter.DEAD_STATE_RCL1_AFTER_STABLE_REASON],
+        )
+        self.assertEqual(skipped_sample["priorMaxRcl"], 4)
+
     def test_dead_state_runtime_samples_can_be_kept_for_recovery_mode(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -596,6 +633,19 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(quarantine["zero_creep_samples"], 1)
         self.assertEqual(quarantine["rcl1_samples"], 1)
         self.assertEqual(quarantine["training_eligibility"], "recovery_mode_dataset")
+        dead_state_rows = [
+            row
+            for row in rows
+            if row["observation"]["controller"]["level"] == exporter.COLLAPSED_ROOM_RCL_LEVEL
+        ]
+        self.assertEqual(len(dead_state_rows), 1)
+        self.assertEqual(
+            dead_state_rows[0][exporter.DEAD_STATE_SAMPLE_MARKER]["reasons"],
+            [
+                exporter.DEAD_STATE_ZERO_CREEP_REASON,
+                exporter.DEAD_STATE_RCL1_AFTER_STABLE_REASON,
+            ],
+        )
 
     def test_owned_room_count_collapse_quarantines_current_window_samples(self) -> None:
         prior_payload = active_runtime_payload(2558700, room_name="E29N55", rcl=6)

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -19,6 +19,44 @@ def runtime_line(payload: dict[str, object]) -> str:
     return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
 
 
+def active_runtime_payload(tick: int, *, room_name: str = "E29N55", rcl: int = 4) -> dict[str, object]:
+    return {
+        "type": "runtime-summary",
+        "tick": tick,
+        "rooms": [
+            {
+                "roomName": room_name,
+                "energyAvailable": 300,
+                "workerCount": 4,
+                "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                "taskCounts": {"harvest": 1, "upgrade": 1, "none": 0},
+                "controller": {"level": rcl, "progress": 1000, "ticksToDowngrade": 10000},
+                "resources": {"storedEnergy": 500, "workerCarriedEnergy": 25},
+                "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
+            }
+        ],
+    }
+
+
+def dead_state_runtime_payload(tick: int, *, room_name: str = "E29N55") -> dict[str, object]:
+    return {
+        "type": "runtime-summary",
+        "source": "screeps-runtime-monitor",
+        "tick": tick,
+        "rooms": [
+            {
+                "roomName": room_name,
+                "rclLevel": 1,
+                "taskCounts": {"harvest": 0, "upgrade": 0, "build": 0, "none": 0},
+                "controller": {"level": 1, "progress": 0, "progressTotal": 0},
+                "resources": {"storedEnergy": 2430, "workerCarriedEnergy": 0},
+                "workerAssignmentEvidence": {"workerCount": 0, "visibleCreepCount": 0},
+                "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
+            }
+        ],
+    }
+
+
 def read_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -475,7 +513,136 @@ class RlDatasetExportTest(unittest.TestCase):
 
         self.assertEqual(summary["sampleCount"], 1)
         self.assertEqual(summary["skippedSampleCount"], 0)
+        self.assertEqual(summary["deadStateQuarantine"]["quarantined_dead_state_samples"], 0)
+        self.assertEqual(summary["deadStateQuarantine"]["zero_creep_samples"], 0)
+        self.assertEqual(summary["deadStateQuarantine"]["rcl1_samples"], 0)
+        self.assertTrue(summary["deadStateQuarantine"]["samples_remain_eligible_for_training"])
         self.assertEqual(rows[0]["observation"]["roomName"], "E29N55")
+
+    def test_dead_state_runtime_samples_are_quarantined_with_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            stable_artifact = root / "runtime-summary-console-20260624T115900Z.log"
+            dead_artifact = root / "runtime-summary-console-20260624T131214Z.log"
+            stable_artifact.write_text(runtime_line(active_runtime_payload(2558700, rcl=4)), encoding="utf-8")
+            dead_artifact.write_text(runtime_line(dead_state_runtime_payload(2560700)), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(stable_artifact), str(dead_artifact)],
+                out_dir,
+                run_id="dead-state-quarantine-run",
+                bot_commit="5" * 40,
+                eval_ratio_value=0,
+                created_at="2026-06-24T16:30:00Z",
+                home_room="E29N55",
+            )
+            rows = read_ndjson(out_dir / "dead-state-quarantine-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "dead-state-quarantine-run" / "source_index.json")
+            run_manifest = read_json(out_dir / "dead-state-quarantine-run" / "run_manifest.json")
+
+        quarantine = summary["deadStateQuarantine"]
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["observation"]["controller"]["level"], 4)
+        self.assertEqual(summary["skippedSampleCount"], 1)
+        self.assertEqual(summary["skippedSampleReasons"], {exporter.DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON: 1})
+        self.assertEqual(quarantine["quarantined_dead_state_samples"], 1)
+        self.assertEqual(quarantine["zero_creep_samples"], 1)
+        self.assertEqual(quarantine["rcl1_samples"], 1)
+        self.assertEqual(quarantine["source_time_range"]["min"], "2026-06-24T11:59:00Z")
+        self.assertEqual(quarantine["source_time_range"]["max"], "2026-06-24T13:12:14Z")
+        self.assertEqual(quarantine["training_eligibility"], "eligible_samples_remain_after_quarantine")
+        self.assertTrue(quarantine["samples_remain_eligible_for_training"])
+        skipped_sample = source_index["skippedSamples"][0]
+        self.assertEqual(skipped_sample["reason"], exporter.DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON)
+        self.assertEqual(
+            skipped_sample["deadStateReasons"],
+            [
+                exporter.DEAD_STATE_ZERO_CREEP_REASON,
+                exporter.DEAD_STATE_RCL1_AFTER_STABLE_REASON,
+            ],
+        )
+        self.assertFalse(skipped_sample["samplesEligibleForTraining"])
+        self.assertEqual(run_manifest["source"]["deadStateQuarantine"], quarantine)
+
+    def test_dead_state_runtime_samples_can_be_kept_for_recovery_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            stable_artifact = root / "runtime-summary-console-20260624T115900Z.log"
+            dead_artifact = root / "runtime-summary-console-20260624T131214Z.log"
+            stable_artifact.write_text(runtime_line(active_runtime_payload(2558700, rcl=4)), encoding="utf-8")
+            dead_artifact.write_text(runtime_line(dead_state_runtime_payload(2560700)), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(stable_artifact), str(dead_artifact)],
+                out_dir,
+                run_id="dead-state-recovery-run",
+                bot_commit="6" * 40,
+                eval_ratio_value=0,
+                created_at="2026-06-24T16:30:00Z",
+                home_room="E29N55",
+                allow_recovery_dead_state_samples=True,
+            )
+            rows = read_ndjson(out_dir / "dead-state-recovery-run" / "ticks.ndjson")
+
+        quarantine = summary["deadStateQuarantine"]
+        self.assertEqual(summary["sampleCount"], 2)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(summary["skippedSampleCount"], 0)
+        self.assertTrue(quarantine["recovery_mode"])
+        self.assertEqual(quarantine["quarantined_dead_state_samples"], 0)
+        self.assertEqual(quarantine["zero_creep_samples"], 1)
+        self.assertEqual(quarantine["rcl1_samples"], 1)
+        self.assertEqual(quarantine["training_eligibility"], "recovery_mode_dataset")
+
+    def test_owned_room_count_collapse_quarantines_current_window_samples(self) -> None:
+        prior_payload = active_runtime_payload(2558700, room_name="E29N55", rcl=6)
+        prior_payload["rooms"].append(
+            {
+                "roomName": "E29N56",
+                "energyAvailable": 300,
+                "workerCount": 2,
+                "spawnStatus": [{"name": "Spawn2", "status": "idle"}],
+                "taskCounts": {"harvest": 1, "upgrade": 0, "none": 0},
+                "controller": {"level": 4, "progress": 1000, "ticksToDowngrade": 10000},
+                "resources": {"storedEnergy": 300, "workerCarriedEnergy": 0},
+                "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
+            }
+        )
+        current_payload = active_runtime_payload(2560700, room_name="E29N55", rcl=3)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            prior_artifact = root / "runtime-summary-console-20260624T115900Z.log"
+            current_artifact = root / "runtime-summary-console-20260624T131214Z.log"
+            prior_artifact.write_text(runtime_line(prior_payload), encoding="utf-8")
+            current_artifact.write_text(runtime_line(current_payload), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(prior_artifact), str(current_artifact)],
+                out_dir,
+                run_id="owned-room-collapse-run",
+                bot_commit="7" * 40,
+                eval_ratio_value=0,
+                created_at="2026-06-24T16:30:00Z",
+                home_room="E29N55",
+            )
+            rows = read_ndjson(out_dir / "owned-room-collapse-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "owned-room-collapse-run" / "source_index.json")
+
+        quarantine = summary["deadStateQuarantine"]
+        self.assertEqual(summary["sampleCount"], 2)
+        self.assertEqual({row["observation"]["roomName"] for row in rows}, {"E29N55", "E29N56"})
+        self.assertEqual(summary["skippedSampleReasons"], {exporter.DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON: 1})
+        self.assertEqual(quarantine["quarantined_dead_state_samples"], 1)
+        self.assertEqual(quarantine["owned_room_collapse_samples"], 1)
+        self.assertIn(
+            exporter.DEAD_STATE_OWNED_ROOM_COLLAPSE_REASON,
+            source_index["skippedSamples"][0]["deadStateReasons"],
+        )
 
     def test_stale_skipped_samples_are_summarized_without_full_source_index_log(self) -> None:
         current_payload = {

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -226,6 +226,11 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(report["quality_checks"]["status"], "pass")
         self.assertEqual(report["quality_checks"]["samples_rejected"], 0)
         self.assertEqual(summary["qualityChecksStatus"], "pass")
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["quarantined_dead_state_samples"], 0)
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["zero_creep_samples"], 0)
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["rcl1_samples"], 0)
+        self.assertTrue(report["datasetGate"]["deadStateQuarantine"]["samples_remain_eligible_for_training"])
+        self.assertEqual(summary["deadStateQuarantine"], report["datasetGate"]["deadStateQuarantine"])
         self.assertEqual(report["shadowEvaluation"]["status"], "pass")
         self.assertEqual(report["historicalValidation"]["status"], "pass")
         self.assertEqual(report["predefinedMetricGate"]["status"], "pass")
@@ -290,6 +295,101 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
             self.assertEqual(baseline_metrics[metric]["source"], "current_runtime_kpi_window")
             self.assertEqual(baseline_metrics[metric]["target"], expected_value)
         self.assertFalse(rollout_decision_exists)
+
+    def test_run_quarantines_dead_state_samples_and_reports_training_eligibility(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            stable_artifact = root / "runtime-summary-console-20260624T115900Z.log"
+            dead_artifact = root / "runtime-summary-console-20260624T131214Z.log"
+            stable_payload = runtime_payload(2558700, stored_energy=1000)
+            stable_payload["rooms"][0]["roomName"] = "E29N55"
+            stable_payload["rooms"][0]["controller"]["level"] = 4
+            dead_payload = runtime_payload(2560700, stored_energy=2430)
+            dead_room = dead_payload["rooms"][0]
+            dead_room["roomName"] = "E29N55"
+            dead_room["workerCount"] = 0
+            dead_room["spawnStatus"] = []
+            dead_room["taskCounts"] = {"harvest": 0, "upgrade": 0, "build": 0, "none": 0}
+            dead_room["controller"]["level"] = 1
+            dead_room["controller"]["progress"] = 0
+            dead_room["resources"]["workerCarriedEnergy"] = 0
+            stable_artifact.write_text(runtime_line(stable_payload), encoding="utf-8")
+            dead_artifact.write_text(runtime_line(dead_payload), encoding="utf-8")
+
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E29N55"}, clear=False):
+                report = gate.run_gate(
+                    [str(stable_artifact), str(dead_artifact)],
+                    out_dir=root / "gates",
+                    gate_id="gate-dead-state-quarantine",
+                    created_at="2026-06-24T16:30:00Z",
+                    dataset_out_dir=root / "datasets",
+                    skip_shadow_report=True,
+                    bot_commit="d" * 40,
+                    eval_ratio_value=0,
+                    repo_root=Path.cwd(),
+                )
+            summary = read_json(root / "gates" / "gate-dead-state-quarantine" / "gate_summary.json")
+
+        dead_state = report["datasetGate"]["deadStateQuarantine"]
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["dataset"]["sampleCount"], 1)
+        self.assertEqual(
+            report["dataset"]["skippedSampleReasons"],
+            {gate.dataset_export.DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON: 1},
+        )
+        self.assertEqual(report["quality_checks"]["status"], "pass")
+        self.assertEqual(dead_state["quarantined_dead_state_samples"], 1)
+        self.assertEqual(dead_state["zero_creep_samples"], 1)
+        self.assertEqual(dead_state["rcl1_samples"], 1)
+        self.assertEqual(
+            dead_state["source_time_range"],
+            {"min": "2026-06-24T11:59:00Z", "max": "2026-06-24T13:12:14Z"},
+        )
+        self.assertTrue(dead_state["samples_remain_eligible_for_training"])
+        self.assertEqual(dead_state["training_eligibility"], "eligible_samples_remain_after_quarantine")
+        self.assertEqual(report["datasetGate"]["diagnostics"]["deadStateQuarantine"], dead_state)
+        self.assertEqual(summary["deadStateQuarantine"], dead_state)
+
+    def test_run_keeps_dead_state_samples_for_explicit_recovery_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime-summary-console-20260624T131214Z.log"
+            dead_payload = runtime_payload(2560700, stored_energy=2430)
+            dead_room = dead_payload["rooms"][0]
+            dead_room["roomName"] = "E29N55"
+            dead_room["workerCount"] = 0
+            dead_room["spawnStatus"] = []
+            dead_room["taskCounts"] = {"harvest": 0, "upgrade": 0, "build": 0, "none": 0}
+            dead_room["controller"]["level"] = 1
+            dead_room["controller"]["progress"] = 0
+            dead_room["resources"]["workerCarriedEnergy"] = 0
+            artifact.write_text(runtime_line(dead_payload), encoding="utf-8")
+
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E29N55"}, clear=False):
+                report = gate.run_gate(
+                    [str(artifact)],
+                    out_dir=root / "gates",
+                    gate_id="gate-recovery-dead-state",
+                    created_at="2026-06-24T16:30:00Z",
+                    dataset_out_dir=root / "datasets",
+                    skip_shadow_report=True,
+                    bot_commit="e" * 40,
+                    eval_ratio_value=0,
+                    allow_recovery_dead_state_samples=True,
+                    repo_root=Path.cwd(),
+                )
+
+        dead_state = report["datasetGate"]["deadStateQuarantine"]
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["dataset"]["sampleCount"], 1)
+        self.assertEqual(report["dataset"]["skippedSampleCount"], 0)
+        self.assertTrue(dead_state["recovery_mode"])
+        self.assertEqual(dead_state["quarantined_dead_state_samples"], 0)
+        self.assertEqual(dead_state["zero_creep_samples"], 1)
+        self.assertEqual(dead_state["rcl1_samples"], 1)
+        self.assertEqual(dead_state["training_eligibility"], "recovery_mode_dataset")
+        self.assertEqual(report["quality_checks"]["status"], "pass")
+        self.assertTrue(report["quality_checks"]["recovery_mode"])
 
     def test_empty_full_gate_input_reports_actionable_source_diagnostics(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -567,7 +667,7 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
                 self.assertEqual(cadence["captureCommandArgs"][-2:], ["--out-dir", expected_source_root])
                 self.assertNotEqual(cadence["captureCommandArgs"][-1], input_paths[0].rstrip("/"))
 
-    def test_run_rejects_dead_room_dataset_samples(self) -> None:
+    def test_run_quarantines_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             artifact = root / "runtime-summary-console-20260517T000000Z.log"
@@ -598,17 +698,26 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
 
         self.assertFalse(report["ok"])
         self.assertFalse(saved_report["ok"])
-        self.assertEqual(report["datasetGate"]["status"], "pass")
-        self.assertEqual(report["quality_checks"]["status"], "fail")
+        self.assertEqual(report["datasetGate"]["status"], "fail")
+        self.assertEqual(report["datasetGate"]["sampleCount"], 0)
+        self.assertEqual(
+            report["datasetGate"]["diagnostics"]["classification"],
+            "all_runtime_samples_quarantined_dead_state",
+        )
+        self.assertEqual(
+            report["dataset"]["skippedSampleReasons"],
+            {gate.dataset_export.DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON: 1},
+        )
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["quarantined_dead_state_samples"], 1)
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["zero_creep_samples"], 1)
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["rcl1_samples"], 0)
+        self.assertFalse(report["datasetGate"]["deadStateQuarantine"]["samples_remain_eligible_for_training"])
+        self.assertEqual(report["quality_checks"]["status"], "pass")
         self.assertEqual(report["quality_checks"]["samples_accepted"], 0)
-        self.assertEqual(report["quality_checks"]["samples_rejected"], 1)
-        self.assertIn("no_harvest_or_upgrade_task", report["quality_checks"]["rejection_reasons"])
-        self.assertIn("no_room_energy", report["quality_checks"]["rejection_reasons"])
-        self.assertIn("no_owned_creeps", report["quality_checks"]["rejection_reasons"])
-        self.assertIn("no_owned_spawns", report["quality_checks"]["rejection_reasons"])
-        self.assertTrue(any(reason["gate"] == "quality_checks" for reason in report["blockingReasons"]))
+        self.assertEqual(report["quality_checks"]["samples_rejected"], 0)
+        self.assertTrue(any(reason["gate"] == "dataset" for reason in report["blockingReasons"]))
 
-    def test_run_rejects_dead_room_console_capture_under_postdeploy_directory(self) -> None:
+    def test_run_quarantines_dead_room_console_capture_under_postdeploy_directory(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             artifact = root / "postdeploy" / "runtime-summary-console-20260517T000000Z.log"
@@ -637,11 +746,19 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
             )
 
         self.assertFalse(report["ok"])
-        self.assertEqual(report["dataset"]["sampleCount"], 1)
-        self.assertEqual(report["quality_checks"]["status"], "fail")
-        self.assertEqual(report["quality_checks"]["samples_rejected"], 1)
-        self.assertIn("no_room_energy", report["quality_checks"]["rejection_reasons"])
-        self.assertIn("no_harvest_or_upgrade_task", report["quality_checks"]["rejection_reasons"])
+        self.assertEqual(report["dataset"]["sampleCount"], 0)
+        self.assertEqual(
+            report["dataset"]["skippedSampleReasons"],
+            {gate.dataset_export.DEAD_STATE_RUNTIME_SAMPLE_SKIP_REASON: 1},
+        )
+        self.assertEqual(
+            report["datasetGate"]["diagnostics"]["classification"],
+            "all_runtime_samples_quarantined_dead_state",
+        )
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["quarantined_dead_state_samples"], 1)
+        self.assertEqual(report["datasetGate"]["deadStateQuarantine"]["zero_creep_samples"], 1)
+        self.assertEqual(report["quality_checks"]["status"], "pass")
+        self.assertEqual(report["quality_checks"]["samples_rejected"], 0)
 
     def test_run_excludes_stale_non_current_console_capture_before_quality_acceptance(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -33,6 +33,11 @@ def read_json(path: Path) -> JsonObject:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def read_ndjson(path: Path) -> list[JsonObject]:
+    text = path.read_text(encoding="utf-8")
+    return [json.loads(line) for line in text.splitlines() if line]
+
+
 def runtime_line(payload: JsonObject) -> str:
     return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
 
@@ -390,6 +395,65 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(dead_state["training_eligibility"], "recovery_mode_dataset")
         self.assertEqual(report["quality_checks"]["status"], "pass")
         self.assertTrue(report["quality_checks"]["recovery_mode"])
+
+    def test_recovery_mode_accepts_owned_room_count_collapse_from_export_marker(self) -> None:
+        prior_payload = runtime_payload(2558700, stored_energy=1000)
+        prior_payload["rooms"][0]["roomName"] = "E29N55"
+        prior_payload["rooms"][0]["controller"]["level"] = 4
+        prior_payload["rooms"].append(
+            {
+                "roomName": "E29N56",
+                "workerCount": 2,
+                "spawnStatus": [{"name": "Spawn2", "status": "idle"}],
+                "taskCounts": {"harvest": 1, "upgrade": 0, "none": 0},
+                "controller": {"level": 4, "progress": 1000, "ticksToDowngrade": 10000},
+                "resources": {"storedEnergy": 300, "workerCarriedEnergy": 0},
+                "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
+            }
+        )
+        current_payload = runtime_payload(2560700, stored_energy=0)
+        current_room = current_payload["rooms"][0]
+        current_room["roomName"] = "E29N55"
+        current_room["workerCount"] = 1
+        current_room["spawnStatus"] = []
+        current_room["taskCounts"] = {"harvest": 0, "upgrade": 0, "build": 0, "none": 1}
+        current_room["controller"]["level"] = 3
+        current_room["resources"]["storedEnergy"] = 0
+        current_room["resources"]["workerCarriedEnergy"] = 0
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            prior_artifact = root / "runtime-summary-console-20260624T115900Z.log"
+            current_artifact = root / "runtime-summary-console-20260624T131214Z.log"
+            prior_artifact.write_text(runtime_line(prior_payload), encoding="utf-8")
+            current_artifact.write_text(runtime_line(current_payload), encoding="utf-8")
+
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E29N55"}, clear=False):
+                report = gate.run_gate(
+                    [str(prior_artifact), str(current_artifact)],
+                    out_dir=root / "gates",
+                    gate_id="gate-recovery-owned-room-collapse",
+                    created_at="2026-06-24T16:30:00Z",
+                    dataset_out_dir=root / "datasets",
+                    skip_shadow_report=True,
+                    bot_commit="f" * 40,
+                    eval_ratio_value=0,
+                    allow_recovery_dead_state_samples=True,
+                    repo_root=Path.cwd(),
+                )
+            rows = read_ndjson(root / "datasets" / report["dataset"]["runId"] / "ticks.ndjson")
+
+        dead_state = report["datasetGate"]["deadStateQuarantine"]
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["quality_checks"]["status"], "pass")
+        self.assertEqual(report["quality_checks"]["samples_rejected"], 0)
+        self.assertEqual(dead_state["owned_room_collapse_samples"], 1)
+        self.assertEqual(dead_state["quarantined_dead_state_samples"], 0)
+        marked_rows = [row for row in rows if isinstance(row.get(gate.dataset_export.DEAD_STATE_SAMPLE_MARKER), dict)]
+        self.assertEqual(len(marked_rows), 1)
+        marker = marked_rows[0][gate.dataset_export.DEAD_STATE_SAMPLE_MARKER]
+        self.assertEqual(marker["reasons"], [gate.dataset_export.DEAD_STATE_OWNED_ROOM_COLLAPSE_REASON])
+        self.assertTrue(marker["ownedRoomCountCollapsed"])
 
     def test_empty_full_gate_input_reports_actionable_source_diagnostics(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Closes #2027.

- Adds a deterministic dead-state quarantine pass to the RL dataset exporter before ordinary training rows are written.
- Quarantines live runtime samples with explicit zero owned creeps, RCL <= 1 after prior stable/collapse evidence, or owned-room-count collapse unless `--allow-recovery-dead-state-samples` is set.
- Surfaces compact E1 gate/readiness evidence: `quarantined_dead_state_samples`, `zero_creep_samples`, `rcl1_samples`, source time range, and training eligibility.
- Keeps all behavior offline/local: no Screeps MMO writes, no live effect, no secrets required.

## Validation

- `python3 -m py_compile scripts/screeps_rl_dataset_export.py scripts/screeps_rl_dataset_gate.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_gate.py`
- `python3 -m unittest scripts.test_screeps_rl_dataset_export scripts.test_screeps_rl_dataset_gate` (51 tests)
- `git diff --check`
- Smoke-tested `/root/screeps/runtime-artifacts/runtime-summary-console/runtime-summary-monitor-20260624T131214Z.log` into `/tmp`; it quarantined one E29N55 zero-creep/RCL1 sample and left zero eligible training rows.

## Safety

- No `prod/` changes.
- No official MMO writes or deploy actions.
- No Tencent run-single, scale-out, or paid compute actions.

## Universal task Done gate

- [x] Task type: scripts/code plus focused Python tests.
- [x] Expected observable outcome / named deliverable: ordinary RL dataset export and E1 gate runs quarantine collapse-window dead-state runtime samples, emit compact counts, and allow those samples only with the explicit recovery-mode flag.
- [x] Non-goals / accepted substitutes: no `prod/` behavior change, no Screeps official MMO write, no deploy, no Tencent compute action.
- [x] Verification evidence required before Done: py_compile passed for touched Python files; unittest dataset_export plus dataset_gate passed 51 tests; git diff --check passed; actual collapse sample smoke quarantined one E29N55 zero-creep/RCL1 sample.
- [x] Project Evidence / Next action / Blocked by: issue #2027 and PR #2028 Project items are In review; Evidence and Next action are populated; no blocker recorded.
- [x] Post-merge/deploy/runtime proof: local real collapse sample smoke proves the runtime-artifact ingestion behavior; deploy proof is outside this script-only PR.
- [x] Named deliverable proof: PR #2028 at head 1acd8ff3 is the deliverable; no external service surface is named.

## Issue closure gate

- [x] #2027: PR #2028 implements dead-state quarantine, recovery-mode opt-in, compact gate evidence counts, and focused regression tests; Project issue and PR entries carry review evidence.